### PR TITLE
Make the compile work on a Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ LDLIBS   =
 CLANG_INSTALLED := $(shell clang++ --version 2>/dev/null)
 ifdef CLANG_INSTALLED
 CXX      = clang++
-CXXFLAGS = -g -Wshadow -Wall -Wfatal-errors -std=c++11 -fPIC
+CXXFLAGS = -g -O2 -Wshadow -Wall -Wfatal-errors -std=c++11 -fPIC
 else
 CXX      = g++
-CXXFLAGS = -g -Wall -Wfatal-errors -fPIC
+CXXFLAGS = -g -O2 -Wall -Wfatal-errors -fPIC
 endif
 
 # File extensions / ignored files.

--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,12 @@ get_src     =  $2/$(call remove_root, $(basename $1)$(SRC_EXT))
 get_bin     = $(filter %$(notdir $1), $(BIN))
 get_bin_dep = $(filter $(subst $(HDR_EXT),$(SRC_EXT), $(filter $(patsubst ./%,%,$(HDR)), $1)), $(patsubst ./%,%,$(SRC)))
 ifeq ($(BUILDTARGET),Darwin)
-DARWINSEDFIX = "\'\'"
-else
-DARWINSEDFIX = ""
-endif
 make_dep    = @$(CXX) -MM $(CXXFLAGS) $1 > $2.d; \
-              sed -i $(DARWINSEDFIX) 's/.*:/$(subst /,\/,$@):/' $@.d
+              sed -i '' 's/.*:/$(subst /,\/,$@):/' $@.d
+else
+make_dep    = @$(CXX) -MM $(CXXFLAGS) $1 > $2.d; \
+              sed -i 's/.*:/$(subst /,\/,$@):/' $@.d
+endif
 
 # Compile a file and print message. Args: <src_file> <dest_file> <cxx_options>
 compile     = @echo "Compiling:   $(strip $1) -> $(strip $2): " $(shell $(call compile_cmd, $1, $2, $3))

--- a/Makefile
+++ b/Makefile
@@ -167,8 +167,8 @@ run_test    = printf "Executing:   $1:  "; \
              if [ $$OUT -eq 0 ]; then \
                  echo "OK"; \
              else \
-                  rm $1; \
-                  exit 1; \
+                 rm $1; \
+                 exit 1; \
              fi \
 
 # Summary message

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ VERSION = 0.6.1
 NAME = fnss
 ARCHIVE_NAME  = fnss-cpp-api-$(VERSION)
 
+# BUILD TARGET
+BUILDTARGET = $(shell uname)
+
 # Compiler options
 LDFLAGS  =
 LDLIBS   =
@@ -41,10 +44,10 @@ LDLIBS   =
 CLANG_INSTALLED := $(shell clang++ --version 2>/dev/null)
 ifdef CLANG_INSTALLED
 CXX      = clang++
-CXXFLAGS = -g -O2 -Wshadow -Wall -Wfatal-errors -std=c++11 -fPIC
+CXXFLAGS = -g -Wshadow -Wall -Wfatal-errors -std=c++11 -fPIC
 else
 CXX      = g++
-CXXFLAGS = -g -O2 -Wall -Wfatal-errors -fPIC
+CXXFLAGS = -g -Wall -Wfatal-errors -fPIC
 endif
 
 # File extensions / ignored files.
@@ -132,8 +135,13 @@ remove_root = $(shell echo $1 | sed s/\[.]\*\[/]\*\[^/]\*\\\///)
 get_src     =  $2/$(call remove_root, $(basename $1)$(SRC_EXT))
 get_bin     = $(filter %$(notdir $1), $(BIN))
 get_bin_dep = $(filter $(subst $(HDR_EXT),$(SRC_EXT), $(filter $(patsubst ./%,%,$(HDR)), $1)), $(patsubst ./%,%,$(SRC)))
+ifeq ($(BUILDTARGET),Darwin)
+DARWINSEDFIX = "\'\'"
+else
+DARWINSEDFIX = ""
+endif
 make_dep    = @$(CXX) -MM $(CXXFLAGS) $1 > $2.d; \
-              sed -i 's/.*:/$(subst /,\/,$@):/' $@.d
+              sed -i $(DARWINSEDFIX) 's/.*:/$(subst /,\/,$@):/' $@.d
 
 # Compile a file and print message. Args: <src_file> <dest_file> <cxx_options>
 compile     = @echo "Compiling:   $(strip $1) -> $(strip $2): " $(shell $(call compile_cmd, $1, $2, $3))
@@ -159,8 +167,8 @@ run_test    = printf "Executing:   $1:  "; \
              if [ $$OUT -eq 0 ]; then \
                  echo "OK"; \
              else \
-                 rm $1; \
-                 exit 1; \
+                  rm $1; \
+                  exit 1; \
              fi \
 
 # Summary message

--- a/src/edge.h
+++ b/src/edge.h
@@ -26,7 +26,7 @@ namespace fnss {
 /**
  * Default buffer size, set if no buffer size is specified in the constructor
  */
-#define DEFAULT_BUFFER_SIZE "100packets"
+#define DEFAULT_BUFFER_SIZE "1kB"
 
 /**
  * Represent an edge of a topology

--- a/src/quantity.cpp
+++ b/src/quantity.cpp
@@ -22,18 +22,18 @@ Quantity::Quantity(const MeasurementUnit &converter_) :
 
 void Quantity::fromString(const std::string &str) {
 
-    std::string regexpstr = "([0-9]+)(\\.[0-9]*)? *([^ \t]*)";
-    std::regex reg(regexpstr);
-    std::smatch match;
-    std::regex_search(str, match, reg);
+	std::string regexpstr = "([0-9]+)(\\.[0-9]*)? *([^ \t]*)";
+	std::regex reg(regexpstr);
+	std::smatch match;
+	std::regex_search(str, match, reg);
 
-    if ( !match.empty() ) {
-        this->value = std::stod(match[1].str() + match[2].str());
-        this->unit = match[3];
-    } else {
-        this->value = 0.0;
-        this->unit = "";
-    }
+	if (!match.empty()) {
+		this->value = std::stod(match[1].str() + match[2].str());
+		this->unit = match[3];
+	} else {
+		this->value = 0.0;
+		this->unit = "";
+	}
 
 	if(this->unit == "")
 		this->unit = this->converter.getBaseUnit();

--- a/src/quantity.cpp
+++ b/src/quantity.cpp
@@ -1,6 +1,7 @@
 #include "quantity.h"
 
 #include <sstream>
+#include <regex>
 
 namespace fnss {
 
@@ -20,8 +21,19 @@ Quantity::Quantity(const MeasurementUnit &converter_) :
 	value(0), unit(converter_.getBaseUnit()), converter(converter_) {}
 
 void Quantity::fromString(const std::string &str) {
-	std::istringstream ss(str);
-	ss>>this->value>>this->unit;
+
+    std::string regexpstr = "([0-9]+)(\\.[0-9]*)? *([^ \t]*)";
+    std::regex reg(regexpstr);
+    std::smatch match;
+    std::regex_search(str, match, reg);
+
+    if ( !match.empty() ) {
+        this->value = std::stod(match[1].str() + match[2].str());
+        this->unit = match[3];
+    } else {
+        this->value = 0.0;
+        this->unit = "";
+    }
 
 	if(this->unit == "")
 		this->unit = this->converter.getBaseUnit();

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -303,7 +303,7 @@ void testEdge() {
 
 	Edge e;
 
-    e.setBufferSize(Quantity("1kB", Units::Data));
+	e.setBufferSize(Quantity("1kB", Units::Data));
 	// test default values
 	assert(e.getCapacity().toString() == DEFAULT_CAPACITY);
 	assert(e.getDelay().toString() == DEFAULT_DELAY);
@@ -526,7 +526,7 @@ void testQuantity() {
 	Quantity t2(1, "h", Units::Time);
 	Quantity t3("60min", Units::Time);
 	Quantity t4("3601 sec", Units::Time);
-	//t1.fromString("2days");
+	t1.fromString("2days");
 	assert(t2 == t3);
 	assert(t4 > t2);
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -522,7 +522,7 @@ void testEvent() {
 
 void testQuantity() {
 	cout<<"Quantity test: ";
-	Quantity t1("2 days",Units::Time);
+	Quantity t1("2days",Units::Time);
 	Quantity t2(1, "h", Units::Time);
 	Quantity t3("60min", Units::Time);
 	Quantity t4("3601 sec", Units::Time);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -302,6 +302,8 @@ void testEdge() {
 	cout<<"Edge test: ";
 
 	Edge e;
+
+    e.setBufferSize(Quantity("1kB", Units::Data));
 	// test default values
 	assert(e.getCapacity().toString() == DEFAULT_CAPACITY);
 	assert(e.getDelay().toString() == DEFAULT_DELAY);
@@ -520,11 +522,11 @@ void testEvent() {
 
 void testQuantity() {
 	cout<<"Quantity test: ";
-	Quantity t1(Units::Time);
+	Quantity t1("2 days",Units::Time);
 	Quantity t2(1, "h", Units::Time);
 	Quantity t3("60min", Units::Time);
 	Quantity t4("3601 sec", Units::Time);
-	t1.fromString("2days");
+	//t1.fromString("2days");
 	assert(t2 == t3);
 	assert(t4 > t2);
 


### PR DESCRIPTION
This change:

- sed as used required the addition of a small change to have it work on the Mac. The Makefile was altered to detect the platform and conditionally use sed in different ways in one case.
- it looks like "packets" was once a buffer size measure and it was changed to bytes at some point.  Fix what appears to be a leftover reference to packets.
- parsing of quantities ("2days" for example) seemed to differ by platform (Mac (didn't work) vs Linux (did)).  Replaced parsing approach with one using regular expressions to make it more robust to platform differences between the way std::..stream operator>> parsed.

